### PR TITLE
Bump to node8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_6.x xenial main" | tee /etc/apt/sources.list.d/node.list
+  echo "deb https://deb.nodesource.com/node_8.x xenial main" | tee /etc/apt/sources.list.d/node.list
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \


### PR DESCRIPTION
As discussed - we are now basing off our node / npm builds with node8 LTS

https://github.com/owncloud-ci/php/issues/37#issuecomment-365856313