### PR TITLE
Add Chromium browser for JavaScript testing to use ChromeHeadless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y nodejs git-core && \
+  apt-get install -y nodejs git-core chromium-browser && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,8 @@ RUN apt-get update -y && \
 
 RUN npm install -g yarn npx
 
+ENV CHROME_BIN=/usr/bin/chromium-browser \
+  CHROME_PATH=/usr/lib/chromium/
+
 COPY rootfs /
 WORKDIR /var/www/owncloud


### PR DESCRIPTION
This adds the chromium-browser package which is used by karma to execute tests in a headless Chrome browser.

Further testing of this image will follow tomorrows .... :zzz: 