### PR TITLE
Bump nodejs v11 images to Ubuntu 18.04

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:16.04
+FROM owncloud/ubuntu:18.04
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI NodeJS" \
@@ -8,7 +8,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_11.x xenial main" | tee /etc/apt/sources.list.d/node.list
+  echo "deb https://deb.nodesource.com/node_11.x bionic main" | tee /etc/apt/sources.list.d/node.list
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \

--- a/v11/Dockerfile.amd64
+++ b/v11/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:16.04
+FROM owncloud/ubuntu:18.04
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI NodeJS" \
@@ -8,7 +8,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_11.x xenial main" | tee /etc/apt/sources.list.d/node.list
+  echo "deb https://deb.nodesource.com/node_11.x bionic main" | tee /etc/apt/sources.list.d/node.list
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \


### PR DESCRIPTION
In https://cloud.drone.io/owncloud/ocis/651/1/14 https://github.com/owncloud/ocis/pull/314 I got a weird error:
```
git clone -b master --single-branch --no-tags https://github.com/owncloud/phoenix.git /srv/app/phoenix
error: unknown option `no-tags'
```

I guess that the version of `git` in this docker image is too old. It seems that the `--no-tags` options came out in 2017.

Maybe just bumping this image to use Ubuntu 18.04 will get a more modern `git` and lots of other good stuff.