### PR TITLE
Add node version 12

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,6 +1,7 @@
 def main(ctx):
   versions = [
     'latest',
+    '12',
     '11',
     '10',
   ]

--- a/v12/Dockerfile.amd64
+++ b/v12/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:18.04
+FROM owncloud/ubuntu:20.04
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI NodeJS" \
@@ -7,8 +7,8 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 
 VOLUME ["/var/www/owncloud"]
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_12.x bionic main" | tee /etc/apt/sources.list.d/node.list
+RUN curl -sL https://deb.nodesource.com/setup_12.x -o nodesource_setup.sh && \
+  bash nodesource_setup.sh
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \

--- a/v12/Dockerfile.amd64
+++ b/v12/Dockerfile.amd64
@@ -1,0 +1,25 @@
+FROM owncloud/ubuntu:18.04
+
+LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
+  org.label-schema.name="ownCloud CI NodeJS" \
+  org.label-schema.vendor="ownCloud GmbH" \
+  org.label-schema.schema-version="1.0"
+
+VOLUME ["/var/www/owncloud"]
+
+RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+  echo "deb https://deb.nodesource.com/node_12.x bionic main" | tee /etc/apt/sources.list.d/node.list
+
+RUN apt-get update -y && \
+  apt-get upgrade -y && \
+  apt-get install -y nodejs git-core build-essential libpng16-16 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt update && \
+  apt install yarn
+
+COPY rootfs /
+WORKDIR /var/www/owncloud

--- a/v12/manifest.tmpl
+++ b/v12/manifest.tmpl
@@ -1,0 +1,6 @@
+image: owncloudci/nodejs:12
+manifests:
+  - image: owncloudci/nodejs:12-amd64
+    platform:
+      architecture: amd64
+      os: linux


### PR DESCRIPTION
In a lot of repos we're in need of node version 12 to update to latest versions of deps as it is a requirement for them but as of now our latest is 11. I'd love to add this version. Let me pls know if what I did here is not completely wrong.

Tested by building the image locally, running the image and checking for node version and if `yarn` command is available.