### PR TITLE
Install libfontconfig that is required for PhantomJS

### DIFF
--- a/v10/Dockerfile.amd64
+++ b/v10/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v10/Dockerfile.arm32v7
+++ b/v10/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v10/Dockerfile.arm64v8
+++ b/v10/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v12/Dockerfile.amd64
+++ b/v12/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v12/Dockerfile.arm32v7
+++ b/v12/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v12/Dockerfile.arm64v8
+++ b/v12/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v14/Dockerfile.amd64
+++ b/v14/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v14/Dockerfile.arm32v7
+++ b/v14/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v14/Dockerfile.arm64v8
+++ b/v14/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v15/Dockerfile.amd64
+++ b/v15/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v15/Dockerfile.arm32v7
+++ b/v15/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v15/Dockerfile.arm64v8
+++ b/v15/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v16/Dockerfile.amd64
+++ b/v16/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v16/Dockerfile.arm32v7
+++ b/v16/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v16/Dockerfile.arm64v8
+++ b/v16/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \


### PR DESCRIPTION
When running JS unit tests in core with this docker image I get:
https://drone.owncloud.com/owncloud/core/31985/10/4
```
27 08 2021 07:37:32.147:INFO [launcher]: Starting browser PhantomJS
27 08 2021 07:37:32.173:ERROR [phantomjs.launcher]: /drone/src/build/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs: error while loading shared libraries: libfontconfig.so.1: cannot open shared object file: No such file or directory
```

Install `libfontconfig` so that PhantomJS can be used.

Related issue: https://github.com/owncloud-ci/php/issues/137