### PR TITLE
Install gettext

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v10/Dockerfile.amd64
+++ b/v10/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v10/Dockerfile.arm32v7
+++ b/v10/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v10/Dockerfile.arm64v8
+++ b/v10/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v12/Dockerfile.amd64
+++ b/v12/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v12/Dockerfile.arm32v7
+++ b/v12/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v12/Dockerfile.arm64v8
+++ b/v12/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v14/Dockerfile.amd64
+++ b/v14/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v14/Dockerfile.arm32v7
+++ b/v14/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v14/Dockerfile.arm64v8
+++ b/v14/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v15/Dockerfile.amd64
+++ b/v15/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v15/Dockerfile.arm32v7
+++ b/v15/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v15/Dockerfile.arm64v8
+++ b/v15/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v16/Dockerfile.amd64
+++ b/v16/Dockerfile.amd64
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v16/Dockerfile.arm32v7
+++ b/v16/Dockerfile.arm32v7
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/v16/Dockerfile.arm64v8
+++ b/v16/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 VOLUME ["/var/www/owncloud"]
 
 RUN apt-get update -y && \
-  apt-get install -y git-core build-essential libfontconfig libpng16-16 lsb-release && \
+  apt-get install -y gettext git-core build-essential libfontconfig libpng16-16 lsb-release && \
   curl -SsL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \


### PR DESCRIPTION
In files_mediaviewer there is CI: https://drone.owncloud.com/owncloud/files_mediaviewer/938/1/3

`../node_modules/.bin/gettext-extract --attribute v-translate \` ...

And that complains about `xgettext: Command not found`

`xgettext` comes with `gettext` in Ubuntu. Install it in this docker image.