### PR TITLE
add chrome

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -24,6 +24,8 @@ RUN apt-get update -y && \
   echo "deb https://deb.nodesource.com/node_16.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
   apt-get update -y && \
   apt-get install -y nodejs && \
+  wget -q -P /tmp https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  apt install -y /tmp/google-chrome-stable_current_amd64.deb && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/v10/Dockerfile.amd64
+++ b/v10/Dockerfile.amd64
@@ -24,6 +24,8 @@ RUN apt-get update -y && \
   echo "deb https://deb.nodesource.com/node_10.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
   apt-get update -y && \
   apt-get install -y nodejs && \
+  wget -q -P /tmp https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  apt install -y /tmp/google-chrome-stable_current_amd64.deb && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/v12/Dockerfile.amd64
+++ b/v12/Dockerfile.amd64
@@ -24,6 +24,8 @@ RUN apt-get update -y && \
   echo "deb https://deb.nodesource.com/node_12.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
   apt-get update -y && \
   apt-get install -y nodejs && \
+  wget -q -P /tmp https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  apt install -y /tmp/google-chrome-stable_current_amd64.deb && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/v14/Dockerfile.amd64
+++ b/v14/Dockerfile.amd64
@@ -24,6 +24,8 @@ RUN apt-get update -y && \
   echo "deb https://deb.nodesource.com/node_14.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
   apt-get update -y && \
   apt-get install -y nodejs && \
+  wget -q -P /tmp https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  apt install -y /tmp/google-chrome-stable_current_amd64.deb && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/v15/Dockerfile.amd64
+++ b/v15/Dockerfile.amd64
@@ -24,6 +24,8 @@ RUN apt-get update -y && \
   echo "deb https://deb.nodesource.com/node_15.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
   apt-get update -y && \
   apt-get install -y nodejs && \
+  wget -q -P /tmp https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  apt install -y /tmp/google-chrome-stable_current_amd64.deb && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/v16/Dockerfile.amd64
+++ b/v16/Dockerfile.amd64
@@ -24,6 +24,8 @@ RUN apt-get update -y && \
   echo "deb https://deb.nodesource.com/node_16.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
   apt-get update -y && \
   apt-get install -y nodejs && \
+  wget -q -P /tmp https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  apt install -y /tmp/google-chrome-stable_current_amd64.deb && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Chrome is needed by https://github.com/owncloud/web/pull/5856 for testing with PlayWright.

Downside of this PR: AMD64 and ARM images are no longer the same.

Why is this a big mess?
- Chrome (which is installed in this PR) is only available for AMD64 and not for ARM
- Chromium on Ubuntu is distributed as Snap. Snap is not supported in Docker.
- Playwright Docker image is broken (` browserType.launch: Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome -- Run "npx playwright install chrome"`)
