### PR TITLE
chore: bump node v20 to v20.17

### DIFF
--- a/v20/Dockerfile.amd64
+++ b/v20/Dockerfile.amd64
@@ -23,9 +23,9 @@ RUN apt-get update -y && \
   curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_20.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
+  curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get update -y && \
-  apt-get install -y nodejs && \
+  apt-get install -y nodejs=20.17.0-1nodesource1 && \
   wget -q -P /tmp https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
   apt install -y /tmp/google-chrome-stable_current_amd64.deb && \
   apt-get clean && \

--- a/v20/Dockerfile.arm64v8
+++ b/v20/Dockerfile.arm64v8
@@ -23,9 +23,9 @@ RUN apt-get update -y && \
   curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
   chmod 755 /usr/local/bin/retry && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_20.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/node.list && \
+  curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get update -y && \
-  apt-get install -y nodejs && \
+  apt-get install -y nodejs=20.17.0-1nodesource1 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Follow-up for https://github.com/owncloud-ci/nodejs/pull/135, since it used an older version `v20.5`.