### PR TITLE
Update nodejs from 20.17.0 to 20.19.0

### DIFF
--- a/v20/Dockerfile.amd64
+++ b/v20/Dockerfile.amd64
@@ -25,7 +25,7 @@ RUN apt-get update -y && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get update -y && \
-  apt-get install -y nodejs=20.17.0-1nodesource1 && \
+  apt-get install -y nodejs=20.19.0-1nodesource1 && \
   wget -q -P /tmp https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
   apt install -y /tmp/google-chrome-stable_current_amd64.deb && \
   apt-get clean && \

--- a/v20/Dockerfile.arm64v8
+++ b/v20/Dockerfile.arm64v8
@@ -25,7 +25,7 @@ RUN apt-get update -y && \
   curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get update -y && \
-  apt-get install -y nodejs=20.17.0-1nodesource1 && \
+  apt-get install -y nodejs=20.19.0-1nodesource1 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
This PR updates nodejs from 20.17.0 to 20.19.0

Doing so silences the `web-extensions` repo from complaining that:
"Vite requires Node.js version 20.19+ or 22.12+. Please upgrade your Node.js version."
The web-extension repo currently uses node v20

@DeepDiver1975 