### PR TITLE
chore: use multi-arch base image directly

### DIFF
--- a/v20/Dockerfile.multiarch
+++ b/v20/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:20.04
+FROM owncloud/ubuntu:20.04@sha256:ae5ffb91c7aaa60d4cd709227746e8027f4fb7ff684a0813ade8f3e7ded2a22e
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI NodeJS" \

--- a/v20/Dockerfile.multiarch
+++ b/v20/Dockerfile.multiarch
@@ -1,8 +1,4 @@
-FROM owncloud/ubuntu:20.04-amd64@sha256:de7decaa013d5933c855ed2475c36b3d5991a821e847da4be2ceeecb68f3093d AS base-amd64
-FROM owncloud/ubuntu:20.04-arm64v8@sha256:f2bf53708c8e5393371e106e621e8b458557da2bf7d056a79dc3b3a1ad98cb06 AS base-arm64
-
-ARG TARGETARCH
-FROM base-${TARGETARCH}
+FROM owncloud/ubuntu:20.04
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI NodeJS" \

--- a/v22/Dockerfile.multiarch
+++ b/v22/Dockerfile.multiarch
@@ -1,8 +1,4 @@
-FROM owncloud/ubuntu:22.04-amd64@sha256:4c7cd5f9c40b28cd12ce780d7b34cb18ad4a6c7039bbb764d23edc8498ad2e6b AS base-amd64
-FROM owncloud/ubuntu:22.04-arm64v8@sha256:21fe74802e2a3ac9d73ba854c6551dbddeb6304c69b89150ae215b2ea7566930 AS base-arm64
-
-ARG TARGETARCH
-FROM base-${TARGETARCH}
+FROM owncloud/ubuntu:22.04
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI NodeJS" \

--- a/v22/Dockerfile.multiarch
+++ b/v22/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:22.04
+FROM owncloud/ubuntu:22.04@sha256:872b791ab2d46d2ea6c8f3f52889fdd6846ff91c560379ec4ebd2985f56db9cc
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI NodeJS" \

--- a/v24/Dockerfile.multiarch
+++ b/v24/Dockerfile.multiarch
@@ -1,8 +1,4 @@
-FROM owncloud/ubuntu:22.04-amd64@sha256:4c7cd5f9c40b28cd12ce780d7b34cb18ad4a6c7039bbb764d23edc8498ad2e6b AS base-amd64
-FROM owncloud/ubuntu:22.04-arm64v8@sha256:21fe74802e2a3ac9d73ba854c6551dbddeb6304c69b89150ae215b2ea7566930 AS base-arm64
-
-ARG TARGETARCH
-FROM base-${TARGETARCH}
+FROM owncloud/ubuntu:22.04
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI NodeJS" \

--- a/v24/Dockerfile.multiarch
+++ b/v24/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:22.04
+FROM owncloud/ubuntu:22.04@sha256:872b791ab2d46d2ea6c8f3f52889fdd6846ff91c560379ec4ebd2985f56db9cc
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.title="ownCloud CI NodeJS" \


### PR DESCRIPTION
## Summary

- `owncloud/ubuntu:20.04` and `owncloud/ubuntu:22.04` are already multi-arch OCI image indices (`linux/amd64` + `linux/arm64`)
- buildx resolves the correct platform layer automatically — no `ARG TARGETARCH` workaround needed
- Replace the 4-line multi-stage `FROM` preamble in `v20`, `v22`, and `v24` Dockerfiles with a plain `FROM owncloud/ubuntu:{version}`

This is a follow-up to #147.

## Test plan

- [ ] Verify all 3 matrix jobs (`20`, `22`, `24`) pass the `Build and push` step in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)